### PR TITLE
repairs for forcing in primitives

### DIFF
--- a/private/list.rhm
+++ b/private/list.rhm
@@ -56,7 +56,7 @@ defwrap wrap_list_get list_get(l, n):
         error(#'list_get, "index out of range")
     | ~else:
         // must be lazy
-        loop(dynamic_force(l), n)
+        loop(dynamic_force(l), dynamic_force(n))
 
 expr.macro 'first':
   ~op_stx self

--- a/private/map.rhm
+++ b/private/map.rhm
@@ -55,17 +55,17 @@ expr.macro 'shMutableMap $(elems && '{ $key_term ...: $(val :: expr_meta.Parsed)
 
 def fail_key = Symbol.gen()
 
-defwrap wrap_map_get_k map_get_k(map :~ Map, key, success, fail):
-  def v = map.get(dynamic_force(key), fail_key)
+defwrap wrap_map_get_k map_get_k(map, key, success, fail):
+  def v = (dynamic_force(map) :~ ReadableMap).get(dynamic_force(key), fail_key)
   if v === fail_key
-  | fail()
-  | success(v)
+  | dynamic_force(fail)()
+  | dynamic_force(success)(v)
 defwrap wrap_map_update map_update(map, key, val):
-  (dynamic_force(map) :~ Map) ++ { dynamic_force(key): dynamic_force(val) } 
+  (dynamic_force(map) :~ Map) ++ { dynamic_force(key): val }
 defwrap wrap_map_set map_set(map, key, val):
   (dynamic_force(map) :~ MutableMap)[dynamic_force(key)] := val
 defwrap wrap_map_remove map_remove(map, key):
-  (dynamic_force(map) :~ Map).remove(key)
+  (dynamic_force(map) :~ Map).remove(dynamic_force(key))
 defwrap wrap_map_delete map_delete(map, key):
   (dynamic_force(map) :~ MutableMap).delete(dynamic_force(key))
 defwrap wrap_map_keys map_keys(map):

--- a/private/string.rhm
+++ b/private/string.rhm
@@ -13,9 +13,9 @@ export:
   string_length
   string_get
 
-defwrap wrap_string_append string_append(a, b): (dynamic_force(a) :: String) ++ dynamic_force(b)
-defwrap wrap_string_get string_get(a :: String, i): (dynamic_force(a) :: String)[dynamic_force(i)]
-defwrap wrap_string_length string_get(a :: String): String.length(dynamic_force(a))
+defwrap wrap_string_append string_append(a, b): (dynamic_force(a) :~ String) ++ dynamic_force(b)
+defwrap wrap_string_get string_get(a, i): (dynamic_force(a) :~ String)[dynamic_force(i)]
+defwrap wrap_string_length string_length(a): (dynamic_force(a) :~ String).length()
 
 // `to_string` doesn't need to force lazy thunks,
 // because printing already does that


### PR DESCRIPTION
Add missing `dynamic_force` to several functions, but remove unnecessary `dynamic_force` in `map_update`.  Also remove (too) early checking in string functions.

Related to #3