### PR TITLE
change to `block`, add implicit `block`s, and add `begin`

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -9,6 +9,6 @@
                      "sandbox-lib"
                      "scribble-lib"))
 
-(define version "0.2")
+(define version "0.3")
 
 (define scribblings '(("scribblings/shplait.scrbl" (multi-page) (language))))

--- a/private/begin.rhm
+++ b/private/begin.rhm
@@ -7,12 +7,10 @@ import:
   "lazy.rhm" open
 
 export:
-  rename:
-    shblock as block
-    shblock as implicit_block
+  begin
 
-expr.macro 'shblock:
-              $defn
+expr.macro 'begin:
+              $expr0
               ...
               $expr':
   ~op_stx self
@@ -22,17 +20,7 @@ expr.macro 'shblock:
     '(unify ~expr $(t_s.type_to_syntax(tv)):
         ~init_tvars: []
         ~defns:
-          defn_or_delay_void($defn)
-          ...           
+          delay($expr0)
+          ...
         ~body: $expr)'
   t_s.wrap_type(e.relocate_span([stx]), tv)
-
-defn.macro 'defn_or_delay_void($e)':
-  match e
-  | '$(d :: defn_meta.Group)':
-      e
-  | ~else:
-      '(delay(unify ~expr $(t_s.type_to_syntax(t.Vd(#false))):
-                ~body:
-                  $e))'
-

--- a/private/def.rhm
+++ b/private/def.rhm
@@ -12,6 +12,7 @@ import:
   "tuple.rhm"!tuple as tu
   "lazy.rhm" open
   "trace.rhm"!traceable.maybe_wrap_traceable
+  "block.rhm".implicit_block
   "blacklist.rhm"
 
 export:
@@ -123,6 +124,9 @@ defn.macro
 | 'define $(lhs :: LHS): $(rhs :: Group)':
     ~op_stx self
     build_def(self, lhs.mutable_tag, [lhs.id, ...], [lhs.type_seq, ...], rhs)
+| 'define $(lhs :: LHS): $rhs_body':
+    ~op_stx self
+    build_def(self, lhs.mutable_tag, [lhs.id, ...], [lhs.type_seq, ...], 'implicit_block: $rhs_body')
 | 'define $(name :: Identifier) ($_) $tail ...':
     ~op_stx self
     syntax_meta.error("invalid definition syntax, possibly should be `fun`", self)

--- a/private/exn.rhm
+++ b/private/exn.rhm
@@ -6,6 +6,7 @@ import:
   "wrap.rhm" open
   "lazy.rhm" open
   "unify.rhm" open
+  "block.rhm".implicit_block
 
 export:
   rename:
@@ -43,7 +44,8 @@ expr.macro 'let_cc $(id :: Identifier):
                       '(($t_s.type_key, $(t_s.type_to_syntax(k_ty))))'                      
                     unify ~expr $(t_s.type_to_syntax(tv)):
                       ~body:
-                        $body»',
+                        implicit_block:
+                          $body»',
                 tv)
 
 defwrap wrap_error error(sym, str): error(dynamic_force(sym),

--- a/private/fun.rhm
+++ b/private/fun.rhm
@@ -11,6 +11,7 @@ import:
   "value.rhm".current_value_tvar_box
   "def.rhm".def as shdef
   "lazy.rhm" open
+  "block.rhm".implicit_block
   "blacklist.rhm"
 
 export:
@@ -48,7 +49,7 @@ meta:
             [arg_id, ...])
 
 value.macro 'function ($arg, ...) $(res_type :: MaybeType):
-               $(body :: Group)':
+               $body':
   ~op_stx self
   let stx = '$self ($arg, ...) $res_type:
                $body'
@@ -58,12 +59,9 @@ value.macro 'function ($arg, ...) $(res_type :: MaybeType):
   t_s.type_to_syntax(arrow_type)
   
 expr.macro 'function ($arg, ...) $(res_type :: MaybeType):
-              $body
-              $more_body
-              ...':
+              $body':
   ~op_stx self
   ~all_stx stx
-  check_no_more(self, '$more_body; ...')
   let tvar_box = Box(IdMap{})
   let (arrow_type :: t.Arrow, [arg_id, ...]):
     parse_function_type(stx, self, tvar_box)
@@ -83,24 +81,19 @@ expr.macro 'function ($arg, ...) $(res_type :: MaybeType):
            ~init_tvars: [($tv_id, $(t_s.type_to_syntax(tv_ty))), ...]
            ~defns:«»
            ~body:
-             $body
+             implicit_block:
+               $body
      »'
   t_s.wrap_type(expr, stx, arrow_type)
 
 defn.macro
 | 'function $(id :: Identifier) ($arg, ...) $(res_type :: MaybeType):
-     $body
-     $more_body
-     ...':
+     $body':
     ~op_stx self
-    check_no_more(self, '$more_body; ...')
     'shdef $id: $(self.relocate(id)) ($arg, ...) $res_type: $body'
 | 'function ($arg, ...) $(res_type :: MaybeType):
-     $body
-     $more_body
-     ...':
+     $body':
     ~op_stx self
-    check_no_more(self, '$more_body; ...')
     '($self ($arg, ...) $res_type: $body)'
   
 expr.macro '$fn call $(args && '($(arg :: expr_meta.Parsed), ...)')':

--- a/private/if.rhm
+++ b/private/if.rhm
@@ -4,6 +4,7 @@ import:
     "type.rhm" as t
   "type_statinfo.rhm" as t_s
   "lazy.rhm" open
+  "block.rhm".implicit_block
 
 export:
   rename:
@@ -11,13 +12,13 @@ export:
     shcond as cond
 
 expr.macro 'shif $tst ...
-            | $thn ...
-            | $els ...':
+            | $thn_body
+            | $els_body':
   ~op_stx self
   ~all_stx stx
   let '$(tst :: expr_meta.Parsed)' = '$tst ...'
-  let '$(thn :: expr_meta.Parsed)' = '$thn ...'
-  let '$(els :: expr_meta.Parsed)' = '$els ...'
+  let '$(thn :: expr_meta.Parsed)' = 'implicit_block: $thn_body'
+  let '$(els :: expr_meta.Parsed)' = 'implicit_block: $els_body'
   let tv = t.gen_tvar(#false)
   let [tst_ty, new_tst] = t_s.lookup_type(tst, tst.group)
   let [thn_ty, new_thn] = t_s.lookup_type(thn, thn.group)
@@ -30,15 +31,15 @@ expr.macro 'shif $tst ...
 expr.macro
 | 'shcond
    | $tst ...:
-       $(body :: Group)
+       $body
    | ...
    | ~else:
-       $(els :: Group)':
+       $els':
     ~op_stx self
     ~all_stx stx
     let '[$(tst :: expr_meta.Parsed), ...]' = '[$tst ..., ...]'
-    let '[$(body :: expr_meta.Parsed), ...]' = '[$body, ...]'
-    let '$(els :: expr_meta.Parsed)' = els
+    let '[$(body :: expr_meta.Parsed), ...]' = '[implicit_block: $body, ...]'
+    let '$(els :: expr_meta.Parsed)' = 'implicit_block: $els'
     let [[tst_ty, new_tst], ...] = [t_s.lookup_type(tst, tst.group), ...]
     let [[body_ty, new_body], ...] = [t_s.lookup_type(body, body.group), ...]
     let [els_ty, new_els] = t_s.lookup_type(els, els.group)
@@ -54,12 +55,12 @@ expr.macro
                   tv)
 | 'shcond
    | $tst ...:
-       $(body :: Group)
+       $body
    | ...':
     ~op_stx self
     ~all_stx stx
     let '[$(tst :: expr_meta.Parsed), ...]' = '[$tst ..., ...]'
-    let '[$(body :: expr_meta.Parsed), ...]' = '[$body, ...]'
+    let '[$(body :: expr_meta.Parsed), ...]' = '[implicit_block: $body, ...]'
     let tv = t.gen_tvar(self)
     let [[tst_ty, new_tst], ...] = [t_s.lookup_type(tst, tst.group), ...]
     let [[body_ty, new_body], ...] = [t_s.lookup_type(body, body.group), ...]

--- a/private/let.rhm
+++ b/private/let.rhm
@@ -9,19 +9,21 @@ export:
   letrec
 
 expr.macro 'shlet $(id :: Identifier) = $rhs ...:
-              $(body :: Group)':
+              $body':
   ~all_stx stx
   def tmp = Syntax.make_temp_id(id, ~keep_name: #true)
   '(b.block:
       d.def $tmp = $rhs ...
       $('(b.block:
             d.def $id = $tmp
-            $body)'.relocate_span([stx])))'.relocate_span([stx])
+            b.implicit_block:
+              $body)'.relocate_span([stx])))'.relocate_span([stx])
 
 expr.macro 'letrec $(id :: Identifier) = $rhs ...:
-              $(body :: Group)':
+              $body':
   ~all_stx stx
   '(b.block:
       d.def $id = $rhs ...
-      $body)'.relocate_span([stx])
+      b.implicit_block:
+        $body)'.relocate_span([stx])
 

--- a/private/main.rhm
+++ b/private/main.rhm
@@ -8,6 +8,7 @@ import:
   "def.rhm"
   "fun.rhm"
   "block.rhm"
+  "begin.rhm"
   "let.rhm"
   "if.rhm"
   "match.rhm"
@@ -37,6 +38,7 @@ export:
   all_from(.def)
   all_from(.fun)
   all_from(.block)
+  all_from(.begin)
   all_from(.let)
   all_from(.if)
   all_from(.match)

--- a/private/match.rhm
+++ b/private/match.rhm
@@ -10,6 +10,7 @@ import:
   "syntax.rhm"!convert.convert_pat
   "syntax.rhm"!convert.syntax_def
   "syntax.rhm"!convert.syntax_unwrap
+  "block.rhm".implicit_block
   "lazy.rhm" open
   "blacklist.rhm"
 
@@ -25,32 +26,32 @@ meta:
       f_id
       r_id
       cons_body
-  | '| []: $(empty_body :: Group)
-     | $(bound_as expr_meta.space: 'cons')($(f_id :: Identifier), $(r_id :: Identifier)): $(cons_body :: Group)'
-  | '| $(bound_as expr_meta.space: 'cons')($(f_id :: Identifier), $(r_id :: Identifier)): $(cons_body :: Group)
-     | []: $(empty_body :: Group)'
-  | '| []: $(empty_body :: Group)
-     | ~else: $(cons_body :: Group)':
+  | '| []: $empty_body
+     | $(bound_as expr_meta.space: 'cons')($(f_id :: Identifier), $(r_id :: Identifier)): $cons_body'
+  | '| $(bound_as expr_meta.space: 'cons')($(f_id :: Identifier), $(r_id :: Identifier)): $cons_body
+     | []: $empty_body'
+  | '| []: $empty_body
+     | ~else: $cons_body':
       field f_id: 'f'
       field r_id: 'r'
-  | '| $(bound_as expr_meta.space: 'cons')($(f_id :: Identifier), $(r_id :: Identifier)): $(cons_body :: Group)
-     | ~else: $(empty_body :: Group)'
+  | '| $(bound_as expr_meta.space: 'cons')($(f_id :: Identifier), $(r_id :: Identifier)): $cons_body
+     | ~else: $empty_body'
 
   syntax_class OneListClause:
-  | '[]: $(empty_body :: Group)'
-  | '$(bound_as expr_meta.space: 'cons')($(f_id :: Identifier), $(r_id :: Identifier)): $(cons_body :: Group)'
+  | '[]: $empty_body'
+  | '$(bound_as expr_meta.space: 'cons')($(f_id :: Identifier), $(r_id :: Identifier)): $cons_body'
 
   syntax_class SyntaxClauses:
     fields:
       [pat, ...]
       [body, ...]
       else_body
-  | '«| '$pat': $(body :: Group)
+  | '«| '$pat': $body
       | ...»':
       field else_body = #false
-  | '«| '$pat': $(body :: Group)
+  | '«| '$pat': $body
       | ...
-      | ~else: $(else_body :: Group)»'
+      | ~else: $else_body»'
 
   syntax_class.together:
     syntax_class LiteralPattern:
@@ -67,18 +68,18 @@ meta:
       [lits, ...]
       [body, ...]
       else_body
-  | '«| $(lits_in :: LiteralPattern): $(body :: Group)
+  | '«| $(lits_in :: LiteralPattern): $body
       | ...»':
       field else_body = #false
       field [lits, ...] = [lits_in.parsed, ...]
-  | '«| $(lits_in :: LiteralPattern): $(body :: Group)
+  | '«| $(lits_in :: LiteralPattern): $body
       | ...
-      | ~else: $(else_body :: Group)»':
+      | ~else: $else_body»':
       field [lits, ...] = [lits_in.parsed, ...]
 
 expr.macro
 | 'shmatch $expr ...
-   | ~else: $(body :: Group)':
+   | ~else: $body':
     ~op_stx self
     ~all_stx stx
     parse_else_match(self, stx,
@@ -113,10 +114,10 @@ expr.macro
                      ccs.else_body)
 | 'shmatch $expr ...
    | $(ctr :: Identifier) ($(field :: Identifier), ...):
-       $(body :: Group)
+       $body
    | ...
    | $(else_kw && '~else'):
-       $(else_body :: Group)':
+       $else_body':
     ~op_stx self
     ~all_stx stx
     parse_match(self, stx, else_kw,
@@ -126,7 +127,7 @@ expr.macro
                 else_body)
 | 'shmatch $expr ...
    | $(ctr :: Identifier) ($(field :: Identifier), ...):
-       $(body :: Group)
+       $body
    | ...':
     ~op_stx self
     ~all_stx stx
@@ -167,7 +168,8 @@ meta:
       '«match force($new_expr)
         | []: unify ~expr $(t_s.type_to_syntax(tv)):
                 ~body:
-                  $empty_body 
+                  implicit_block:
+                    $empty_body 
         | Pair.cons(first, rest):
             def $f_id = first
             def $r_id = rest
@@ -175,7 +177,8 @@ meta:
             statinfo.macro '$r_id': '(($t_s.type_key, $(t_s.type_to_syntax(t.ListOf(self, elem_tv)))))'
             unify ~expr $(t_s.type_to_syntax(tv)):
               ~body:
-                $cons_body»'
+                implicit_block:
+                  $cons_body»'
     t_s.wrap_type(r, self, tv)
 
   fun parse_syntax_match(self, stx,
@@ -197,7 +200,8 @@ meta:
       | ['~else:
             unify ~expr $(t_s.type_to_syntax(tv)):
               ~body:
-                $else_body']
+                implicit_block:
+                  $else_body']
       | []
     let r:
       '«match syntax_unwrap(force($new_expr))
@@ -206,7 +210,8 @@ meta:
             ...
             unify ~expr $(t_s.type_to_syntax(tv)):
               ~body:
-                $body
+                implicit_block:
+                  $body
         | ...
         | $else
         | ...»'
@@ -229,14 +234,16 @@ meta:
       | ['~else:
             unify ~expr $(t_s.type_to_syntax(tv)):
               ~body:
-                $else_body']
+                implicit_block:
+                  $else_body']
       | []
     let r:
       '«$('match'.relocate_span([self])) $new_expr
         | $lits:
             unify ~expr $(t_s.type_to_syntax(tv)):
               ~body:
-                $body
+                implicit_block:
+                  $body
         | ...
         | $else
         | ...»'
@@ -290,7 +297,8 @@ meta:
       | ['~else:
             unify ~expr $(t_s.type_to_syntax(tv)):
               ~body:
-                $else_body']
+                implicit_block:
+                  $else_body']
       | []
     let r:
       '«match force($new_expr)
@@ -301,7 +309,8 @@ meta:
             ...
             unify ~expr $(t_s.type_to_syntax(tv)):
               ~body:
-                $body
+                implicit_block:
+                  $body
         | ...
         | $else
         | ...»'
@@ -318,7 +327,8 @@ meta:
                      $expr
                      unify ~expr $(t_s.type_to_syntax(tv)):
                        ~body:
-                         $body',
+                         implicit_block:
+                           $body',
                   stx,
                   tv)
 
@@ -342,11 +352,6 @@ expr.macro '$left shis_a $(ctr :: Identifier)':
                 t.Bool(self))
 
 meta:
-  syntax_class MustBeGroup(stx):
-    kind: ~multi
-  | '$(g :: Group)'
-  | '$m':
-      syntax_meta.error("expected a single expression", stx, m)
   syntax_class MustBeIdentifier(stx):
   | '$(id :: Identifier)'
   | '$(id :: Identifier) $next $tail ...':
@@ -356,20 +361,20 @@ meta:
 
   fun check_clause_shape(clause, stx):
     match clause
-    | ': []: $(body :: MustBeGroup(stx))': #void
+    | ': []: $body': #void
     | ': [] $tail ...':
         syntax_meta.error("bad empty-list clause", stx, clause)
     | ': $(bound_as expr_meta.space: 'cons')($(f_id :: MustBeIdentifier(stx)), $(r_id :: MustBeIdentifier(stx))):
-           $(cons_body :: MustBeGroup(stx))':
+           $cons_body':
         #void
     | ': $(bound_as expr_meta.space: 'cons') $tail ...':
         syntax_meta.error("bad cons clause", stx, clause)
     | ': $(ctr :: Identifier) ($(field :: MustBeIdentifier(stx)), ...):
-           $(body :: MustBeGroup(stx))':
+           $body':
         #void
-    | ': «'$pat': $(body :: MustBeGroup(stx))»':
+    | ': «'$pat': $body»':
         #void
-    | ': $(_ :: LiteralPattern): $(body :: MustBeGroup(stx))':
+    | ': $(_ :: LiteralPattern): $body':
         #void
     | '$_':
         syntax_meta.error("bad clause", stx, clause)

--- a/scribblings/demo.rhm
+++ b/scribblings/demo.rhm
@@ -410,6 +410,17 @@ fun to_the_fourth(x):
 
 to_the_fourth(10)      // => 10000
 
+fun also_to_the_fourth(x):
+  // function body has an implicit `block`
+  // (as does `if`, `cond`, and more)
+  fun squared(n):
+    n * n
+  squared(squared(x))
+
+also_to_the_fourth(10)      // => 10000
+
+to_the_fourth(10)      // => 10000
+
 block:
   fun num_is_odd(x):
     if x == 0

--- a/scribblings/tutorial.scrbl
+++ b/scribblings/tutorial.scrbl
@@ -617,19 +617,20 @@ form.
     approx_cirle_area // not visible outside the block
 )
 
-The @rhombus(block) form is typically used inside a function to define
-a helper function or to avoid a repeated computation involving the
-function arguments.
+The @rhombus(block) could be used inside a function to define a helper
+function or to avoid a repeated computation involving the function
+arguments. In cases like the body of @rhombus(fun), however, there is an
+implciit @rhombus(block), so you can just write local definitions there
+directly.
 
 @interaction(
   ~defn:
     fun discard_first_if_fruit(items):
-      block:
-        def a = first(items)
-        cond
-        | a == "apple": rest(items)
-        | a == "banana": rest(items)
-        | ~else: items
+      def a = first(items)
+      cond
+      | a == "apple": rest(items)
+      | a == "banana": rest(items)
+      | ~else: items
   ~repl:
     discard_first_if_fruit(["apple", "potato"])
     discard_first_if_fruit(["banana", "potato"])
@@ -637,10 +638,9 @@ function arguments.
 )
 
 The @rhombus(let) and @rhombus(letrec) forms are similar to
-@rhombus(block) with just one definition, but they are somewhat more
-compact by avoiding the requirement to write both @rhombus(block) and
-@rhombus(def). The @rhombus(discard_first_if_fruit) example above can be
-equivalently written using @rhombus(let):
+@rhombus(block) with just one definition. The
+@rhombus(discard_first_if_fruit) example above can be equivalently
+written using @rhombus(let):
 
 @interaction(
   ~defn:
@@ -650,6 +650,23 @@ equivalently written using @rhombus(let):
         | a == "apple": rest(items)
         | a == "banana": rest(items)
         | ~else: items
+)
+
+Although you can write multiple expressions in a @rhombus(block), since
+those expressions other than the last one do not contribute to the
+result of the block, those expressions must have type @rhombus(Void).
+The intent is to allow priting or other side-effecting expressions while
+disallowing expressions whose result is ignored.
+
+@interaction(
+  ~repl:
+    block:
+      println("Adding...")
+      1+2
+    ~error:
+      block:
+        3+4 // not ok to ignore Int result
+        1+2
 )
 
 @// ----------------------------------------

--- a/tests/syntax_error.rhm
+++ b/tests/syntax_error.rhm
@@ -30,7 +30,7 @@ check_eval:
   match [] | []: "ok" | cons(x, y):
                           "ok"
                           "oops"
-  ~raises "expected a single expression"
+  ~raises "typecheck failed: Void vs. String"
 
 check_eval:
   match [] | cons(x, y): "oops"
@@ -97,10 +97,16 @@ check_eval:
   fun f(x :: Int):
     1
     2
-  ~raises "unexpected term"
+  ~raises "typecheck failed: Void vs. Int"
 
 check_eval:
   fun f(x :: Int) :: Int:
     1
     2
-  ~raises "unexpected term"
+  ~raises "typecheck failed: Void vs. Int"
+
+check_eval:
+  block:
+    1+2
+    3+3
+  ~raises "typecheck failed: Void vs. Int"


### PR DESCRIPTION
An explicit `block` form was intended to help students avoid the mistake of writing two separate expressions and forgetting to combine them somehow. But in parallel to Rhombus, `block` is also explained as the form to support local definitions. The problem is that students then know about `block` and expect to use it, and they sometimes write two expressions in `block` where one is ignored.

This commit changes `block` to still allow a mixture of definitions and expressions, but require that all expressions except the last has type `Void`, which all but prevents writing a useless expresion whose result is ignored. Since the main danger of multiple expressions is thus removed, we go further in making `block` implicit in places like the body of `fun` or the branch-result positions of `match`, `cond`, and `if`. Finally, because we eventually need to ignore non-`Void` results, this commit adds `begin` (matching Moe with state, although generalized to multiple expressions instead of just two).