### PR TITLE
doc: explain the list variants

### DIFF
--- a/scribblings/shplait.scrbl
+++ b/scribblings/shplait.scrbl
@@ -1465,6 +1465,11 @@ Using square brackets implicitly uses the @rhombus(#%brackets) form, but
 
  The type of a list whose elements have type @rhombus(type).
 
+ A list is either empty or a pair of an element and a smaller list:
+ @itemlist(
+   @item{@rhombus([])}
+   @item{@rhombus(cons(first_elem, rest_list))})
+
 }
 
 @doc(


### PR DESCRIPTION
Proposal: explain the 2 list variants where `Listof` is defined so its easy to figure out how to match on a list.
