### PR TITLE
fix behavior of `!=` on mutable values

### DIFF
--- a/private/arithmetic.rhm
+++ b/private/arithmetic.rhm
@@ -83,7 +83,8 @@ decl.macro 'def_equality $op $as_op':
                     t.Bool(self))»'
 
 def_equality == is_now
-def_equality != !=
+operator (x not_is_now y): !(x is_now y)
+def_equality != not_is_now
 def_equality === ===
 
 export:

--- a/tests/equal.rhm
+++ b/tests/equal.rhm
@@ -9,6 +9,19 @@ check:
   box(1) == box(1)
   ~is #true
 
+check:
+  box(1) == box(2)
+  ~is #false
+
+// `!=` is Rhombus's `is_now`, but negated
+check:
+  box(1) != box(1)
+  ~is #false
+
+check:
+  box(1) != box(2)
+  ~is #true
+
 // `~is` is Rhombus's `~is_now`
 check:
   box(1)


### PR DESCRIPTION
Shplait `!=` should be negated Rhombus `is_now`, not Rhombus `!=` (which is negated Rhombus `==`).