### PR TITLE
docs: avoid reporting `check` example as external test failure

### DIFF
--- a/scribblings/eval.rhm
+++ b/scribblings/eval.rhm
@@ -5,12 +5,14 @@ import:
   lib("racket/sandbox.rkt").#{call-in-sandbox-context}
 
 export:
+  make_eval
+  s.close_eval
+
+fun make_eval(~attach: attach = #true):
+  let eval = s.make_rhombus_eval(~lang: #'shplait,
+                                 ~attach: attach)
+  #{call-in-sandbox-context}(eval,
+                             fun ():
+                               racket.#{error-print-context-length}(0)
+                               racket.#{error-print-source-location}(#false))
   eval
-
-def eval = s.make_rhombus_eval(~lang: #'shplait)
-          
-#{call-in-sandbox-context}(eval,
-                           fun ():
-                             racket.#{error-print-context-length}(0)
-                             racket.#{error-print-source-location}(#false))
-

--- a/scribblings/shplait.scrbl
+++ b/scribblings/shplait.scrbl
@@ -5,7 +5,7 @@
       only_meta 0:
         shplait open
       shplait.replace_scopes
-    "eval.rhm".eval
+    "eval.rhm" open
     "tutorial_url.rhm" open
     "spacer.rhm" open)
 
@@ -21,6 +21,9 @@
 @(def rhombus_scrbl = ModulePath 'lib("rhombus/scribblings/rhombus.scrbl")')
 
 @(macro 'nodef($id)': '@rhombus($id, ~datum)')
+
+@(def eval = make_eval())
+@(def check_eval = make_eval(~attach: #false))
 
 @title{Shplait Language}
 
@@ -783,7 +786,7 @@ redefining or shadowing the names could easily create confusion:
  printed, but evaluation continues.
 
 @examples(
-  ~eval: eval
+  ~eval: check_eval
   check:
     1+2
     ~is 3
@@ -2768,3 +2771,8 @@ Use @rhombus(~fuel #,(@rhombus(amount, ~var))) as a @tech{language option} to
 specify how much effort should be spent resolving potentially cyclic
 dependencies due to inference of polymorphic recursion. The default fuel
 amount is @rhombus(100).
+
+@// ------------------------------------------------------------
+
+@(close_eval(eval))
+@(close_eval(check_eval))

--- a/scribblings/tutorial.scrbl
+++ b/scribblings/tutorial.scrbl
@@ -5,7 +5,7 @@
     meta_label:
       only_meta 0:
         shplait open
-    "eval.rhm".eval
+    "eval.rhm" open
     "spacer.rhm" open
     scribble/private/typeset_meta
     lib("scribble/core.rkt") as s_core
@@ -25,7 +25,11 @@
 @(def demo_link:
     @elem(~style: s_core.style(#false, PairList[html_prop.#{link-resource}(demo_rhm)])){@filepath{demo.rhm}})
 
-@(macro 'interaction($term, ...)': 'examples(~eval: eval, $term, ...)')
+@(def eval = make_eval())
+@(def check_eval = make_eval(~attach: #false))
+@(macro
+  | 'interaction(~eval: $eval, $g, ...)': 'examples(~eval: $eval, $g, ...)'
+  | 'interaction($g, ...)': 'examples(~eval: eval, $g, ...)')
 
 @(def quotes = @elem{@litchar{'}…@litchar{'}})
 @(def brackets = @elem{@litchar{[}…@litchar{]}})
@@ -932,6 +936,7 @@ the second expression is the expected result of the call. The
 message (and then continues, anyway) if the test fails.
 
 @interaction(
+  ~eval: check_eval
   ~defn:
     fun taste(s):
       cond
@@ -957,6 +962,7 @@ The test checks that the exception's error message contains the
 string.
 
 @interaction(
+  ~eval: check_eval
   ~defn:
     fun always_fail(n :: Int) :: Int:
       error(#'always_fail, "we're not actually returning a number")
@@ -1686,3 +1692,6 @@ by position.
 )
 
 @// ----------------------------------------
+
+@(close_eval(eval))
+@(close_eval(check_eval))


### PR DESCRIPTION
This applies the same change as in racket/rhombus-prototype@3758d2b.