### PR TITLE
Update docs to have correct name for `some` field

### DIFF
--- a/scribblings/tutorial.scrbl
+++ b/scribblings/tutorial.scrbl
@@ -1467,7 +1467,7 @@ for that case, but Shplait predefines a helpful datatype called
 @rhombusblock(
   type Optionof(?a)
   | none()
-  | some(v :: ?a)
+  | some(val :: ?a)
 )
 
 The @rhombus(?a, ~at shplait/type) in this definition of


### PR DESCRIPTION
The real name is `val`, which is defined [here](https://github.com/mflatt/shplait/blob/70af078217cd2f7b25c5aeb3e474ba04acf6a9e4/private/lib.rhm#L15). 